### PR TITLE
Change Get-WmiObject to Get-CimInstance

### DIFF
--- a/PSDResources/Prestart/PSDPrestartMenu.ps1
+++ b/PSDResources/Prestart/PSDPrestartMenu.ps1
@@ -65,7 +65,7 @@ if($val){
             } 
             '4' {
                 Clear-Host
-                Get-WmiObject win32_networkadapter -Filter "netconnectionstatus = 2 and NetEnabled='True' and PhysicalAdapter='True'" | Select-Object Name,MACAddress | FT
+                Get-CimInstance -ClassName win32_networkadapter -Filter "netconnectionstatus = 2 and NetEnabled='True' and PhysicalAdapter='True'" | Select-Object Name,MACAddress | FT
                 Pause
 
             } 
@@ -76,7 +76,7 @@ if($val){
             }
             '6'{
                 Clear-Host
-                $Nics = Get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object IPenabled -eq $true
+                $Nics = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration | Where-Object IPenabled -eq $true
                 Clear-Host
                 $Menu = @{}
                 $Nics | ForEach-Object -Begin {$i = 1} { 

--- a/PSDResources/Prestart/PSDPrestartMenuCustom.ps1
+++ b/PSDResources/Prestart/PSDPrestartMenuCustom.ps1
@@ -85,7 +85,7 @@ exit
             } 
             '4' {
                 Clear-Host
-                Get-WmiObject win32_networkadapter -Filter "netconnectionstatus = 2 and NetEnabled='True' and PhysicalAdapter='True'" | Select-Object Name,MACAddress | FT
+                Get-CimInstance -ClassName win32_networkadapter -Filter "netconnectionstatus = 2 and NetEnabled='True' and PhysicalAdapter='True'" | Select-Object Name,MACAddress | FT
                 Pause
 
             } 
@@ -97,7 +97,7 @@ exit
             }
             '6'{
                 Clear-Host
-                $Nics = Get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object IPenabled -eq $true
+                $Nics = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration | Where-Object IPenabled -eq $true
                 Clear-Host
                 $Menu = @{}
                 $Nics | ForEach-Object -Begin {$i = 1} { 

--- a/Scripts/PSDCustomization.ps1
+++ b/Scripts/PSDCustomization.ps1
@@ -46,7 +46,7 @@ if($PSDDebug -eq $true)
 switch ($Config)
 {
     'Custom' {
-        [string]$SerialNumber = (Get-WmiObject win32_bios).Serialnumber
+        [string]$SerialNumber = (Get-CimInstance -ClassName win32_bios).Serialnumber
         $CleanSerialNumber =  $SerialNumber.Replace("/","").Replace("\","").Replace("|","").Replace("-","").Replace(" ","")
         $CutOfNumber = 10
         $checklength = $CleanSerialNumber.Length

--- a/Scripts/PSDGather.psm1
+++ b/Scripts/PSDGather.psm1
@@ -76,7 +76,7 @@ Function Get-PSDLocalInfo {
 		$LocalInfo['IsServerOS'] = "False"
 
 		# Look up OS details
-		Get-WmiObject Win32_OperatingSystem | ForEach-Object { $LocalInfo['OSCurrentVersion'] = $_.Version; $LocalInfo['OSCurrentBuild'] = $_.BuildNumber }
+		Get-CimInstance -ClassName Win32_OperatingSystem | ForEach-Object { $LocalInfo['OSCurrentVersion'] = $_.Version; $LocalInfo['OSCurrentBuild'] = $_.BuildNumber }
 		if (Test-Path HKLM:System\CurrentControlSet\Control\MiniNT) {
 			$LocalInfo['OSVersion'] = "WinPE"
 		}
@@ -97,7 +97,7 @@ Function Get-PSDLocalInfo {
 		$ipList = @()
 		$macList = @()
 		$gwList = @()
-		Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | ForEach-Object {
+		Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | ForEach-Object {
 			$_.IPAddress | ForEach-Object { $ipList += $_ }
 			$_.MacAddress | ForEach-Object { $macList += $_ }
 			if ($_.DefaultIPGateway) {
@@ -114,7 +114,7 @@ Function Get-PSDLocalInfo {
 		$LocalInfo['IsServer'] = "False"
 		$LocalInfo['IsSFF'] = "False"
 		$LocalInfo['IsTablet'] = "False"
-		Get-WmiObject Win32_SystemEnclosure | ForEach-Object {
+		Get-CimInstance -ClassName Win32_SystemEnclosure | ForEach-Object {
 			$LocalInfo['AssetTag'] = $_.SMBIOSAssetTag.Trim()
 			if ($_.ChassisTypes[0] -in "8", "9", "10", "11", "12", "14", "18", "21") { $LocalInfo['IsLaptop'] = "True"; $LocalInfo['Chassis'] = "Laptop"}
 			if ($_.ChassisTypes[0] -in "3", "4", "5", "6", "7", "15", "16") { $LocalInfo['IsDesktop'] = "True"; $LocalInfo['Chassis'] = "Desktop"}
@@ -123,7 +123,7 @@ Function Get-PSDLocalInfo {
 			if ($_.ChassisTypes[0] -in "13", "31", "32", "30") {$LocalInfo['IsTablet'] = "True"; $LocalInfo['Chassis'] = "Tablet"}
 		}
 
-		Get-WmiObject Win32_BIOS | ForEach-Object {
+		Get-CimInstance -ClassName Win32_BIOS | ForEach-Object {
 			$LocalInfo['SerialNumber'] = $_.SerialNumber.Trim()
 		}
 
@@ -144,14 +144,14 @@ Function Get-PSDLocalInfo {
 			}
 		}
 
-		Get-WmiObject Win32_Processor | ForEach-Object {
+		Get-CimInstance -ClassName Win32_Processor | ForEach-Object {
 			$LocalInfo['ProcessorSpeed'] = $_.MaxClockSpeed
 			$LocalInfo['SupportsSLAT'] = $_.SecondLevelAddressTranslationExtensions
 		}
 
 		# TODO: Capable architecture
 
-		Get-WmiObject Win32_ComputerSystem | ForEach-Object {
+		Get-CimInstance -ClassName Win32_ComputerSystem | ForEach-Object {
 			$LocalInfo['Manufacturer'] = $_.Manufacturer.Trim()
 			$LocalInfo['Make'] = $_.Manufacturer.Trim()
 			$LocalInfo['Model'] = $_.Model.Trim()
@@ -159,26 +159,26 @@ Function Get-PSDLocalInfo {
 		}
 
 		if ($LocalInfo['Make'] -eq "") {
-			$Make = (Get-WmiObject -Class "Win32_BaseBoard" | Select-Object -ExpandProperty Manufacturer).Trim()
+			$Make = (Get-CimInstance -ClassName "Win32_BaseBoard" | Select-Object -ExpandProperty Manufacturer).Trim()
 			$LocalInfo['Make'] = $Make
 			$LocalInfo['Manufacturer'] = $Make
 		}
 
 		if ($LocalInfo['Model'] -eq "") {
-			$LocalInfo['Model'] = (Get-WmiObject -Class "Win32_BaseBoard" | Select-Object -ExpandProperty Product).Trim()
+			$LocalInfo['Model'] = (Get-CimInstance -ClassName "Win32_BaseBoard" | Select-Object -ExpandProperty Product).Trim()
 		}
 
-		Get-WmiObject Win32_ComputerSystemProduct | ForEach-Object {
+		Get-CimInstance -ClassName Win32_ComputerSystemProduct | ForEach-Object {
 			$LocalInfo['UUID'] = $_.UUID.Trim()
 			$LocalInfo['CSPVersion'] = $_.Version.Trim()
 		}
 
-		Get-CIMInstance -ClassName MS_SystemInformation -NameSpace root\WMI | ForEach-Object {
+		Get-CimInstance -ClassName MS_SystemInformation -Namespace root\WMI | ForEach-Object {
 			$LocalInfo['BaseBoardProduct'] = $_.BaseBoardProduct.Trim()
 			$LocalInfo['SystemSku'] = $_.SystemSku.Trim()
 		}
 
-		Get-WmiObject Win32_BaseBoard | ForEach-Object {
+		Get-CimInstance -ClassName Win32_BaseBoard | ForEach-Object {
 			$LocalInfo['Product'] = $_.Product.Trim()
 		}
 
@@ -197,7 +197,7 @@ Function Get-PSDLocalInfo {
 		$bFoundAC = $false
 		$bOnBattery = $false
 		$bFoundBattery = $false
-		foreach ($Battery in (Get-WmiObject -Class Win32_Battery)) {
+		foreach ($Battery in (Get-CimInstance -ClassName Win32_Battery)) {
 			$bFoundBattery = $true
 			if ($Battery.BatteryStatus -eq "2") {
 				$bFoundAC = $true
@@ -208,7 +208,7 @@ Function Get-PSDLocalInfo {
 		}
 
 		#https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getproductinfo
-		$sku = (Get-WmiObject win32_operatingsystem).OperatingSystemSKU
+		$sku = (Get-CimInstance -ClassName win32_operatingsystem).OperatingSystemSKU
 		switch ($sku)
 		{
 			0       {$LocalInfo['OSSku']="Undefined";break}
@@ -261,80 +261,80 @@ Function Get-PSDLocalInfo {
 		Switch -Wildcard ($LocalInfo['Make']) {
 			"*Microsoft*" {
 				$LocalInfo['MakeAlias'] = "Microsoft"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = Get-WmiObject -Namespace "root\wmi" -Class "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = Get-CimInstance -Namespace "root\wmi" -ClassName "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
 				# Logic for Hyper-V Testing
 				If ($LocalInfo['ModelAlias'] -eq "Virtual Machine") {
-					$LocalInfo['SystemAlias'] = Get-WmiObject -Namespace "root\wmi" -Class "MS_SystemInformation" | Select-Object -ExpandProperty SystemVersion
+					$LocalInfo['SystemAlias'] = Get-CimInstance -Namespace "root\wmi" -ClassName "MS_SystemInformation" | Select-Object -ExpandProperty SystemVersion
 					$LocalInfo['IsVM'] = "True"
 				}
 			}
 			"*HP*" {
 				$LocalInfo['MakeAlias'] = "HP"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace "root\WMI").BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "MS_SystemInformation" -Namespace "root\WMI").BaseBoardProduct.Trim()
 			}
 			"*VMWare*" {
 				$LocalInfo['MakeAlias'] = "VMWare"
-                # $LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim() # Default, sets alias to same as model
-                # $LocalInfo['ModelAlias'] = ((Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()).replace(",","_") # Remove the "," and replace with "_"
-                $LocalInfo['ModelAlias'] = ((Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()).replace(" ","_").replace(",","_") # Remove the "," and replace with "_", Remove the " " and replace with "_"
+                # $LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim() # Default, sets alias to same as model
+                # $LocalInfo['ModelAlias'] = ((Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()).replace(",","_") # Remove the "," and replace with "_"
+                $LocalInfo['ModelAlias'] = ((Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()).replace(" ","_").replace(",","_") # Remove the "," and replace with "_", Remove the " " and replace with "_"
 
-				$LocalInfo['SystemAlias'] = Get-WmiObject -Namespace "root\wmi" -Class "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
+				$LocalInfo['SystemAlias'] = Get-CimInstance -Namespace "root\wmi" -ClassName "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
 				$LocalInfo['IsVM'] = "True"
 			}
 			"*QEMU*" {
 				$LocalInfo['MakeAlias'] = "QEMU"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = Get-WmiObject -Namespace "root\wmi" -Class "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = Get-CimInstance -Namespace "root\wmi" -ClassName "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
 				$LocalInfo['IsVM'] = "True"
 			}
 			"*Innotek*" {
 				$LocalInfo['MakeAlias'] = "Innotek"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = Get-WmiObject -Namespace "root\wmi" -Class "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = Get-CimInstance -Namespace "root\wmi" -ClassName "MS_SystemInformation" | Select-Object -ExpandProperty SystemSKU
 				$LocalInfo['IsVM'] = "True"
 			}
 			"*Hewlett-Packard*" {
 				$LocalInfo['MakeAlias'] = "HP"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace "root\WMI").BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "MS_SystemInformation" -Namespace "root\WMI").BaseBoardProduct.Trim()
 			}
 			"*Dell*" {
 				$LocalInfo['MakeAlias'] = "Dell"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace "root\WMI" ).SystemSku.Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "MS_SystemInformation" -Namespace "root\WMI" ).SystemSku.Trim()
 			}
 			"*Lenovo*" {
 				$LocalInfo['MakeAlias'] = "Lenovo"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystemProduct" | Select-Object -ExpandProperty Version).Trim()
-				$LocalInfo['SystemAlias'] = ((Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).SubString(0, 4)).Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystemProduct" | Select-Object -ExpandProperty Version).Trim()
+				$LocalInfo['SystemAlias'] = ((Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).SubString(0, 4)).Trim()
 			}
 			"*Intel(R) Client Systems*" {
 				$LocalInfo['MakeAlias'] = "Intel(R) Client Systems"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystemProduct" | Select-Object -ExpandProperty Version).Trim()
-				$LocalInfo['SystemAlias'] = ((Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim())
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystemProduct" | Select-Object -ExpandProperty Version).Trim()
+				$LocalInfo['SystemAlias'] = ((Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim())
 				$LocalInfo['SystemAlias'] = $LocalInfo['SystemAlias'].SubString(0, $LocalInfo['SystemAlias'].IndexOf("i")).Trim()
 			}
 			"*Panasonic*" {
 				$LocalInfo['MakeAlias'] = "Panasonic Corporation"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace "root\WMI" ).BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "MS_SystemInformation" -Namespace "root\WMI" ).BaseBoardProduct.Trim()
 			}
 			"*Viglen*" {
 				$LocalInfo['MakeAlias'] = "Viglen"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-WmiObject -Class "Win32_BaseBoard" | Select-Object -ExpandProperty SKU).Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "Win32_BaseBoard" | Select-Object -ExpandProperty SKU).Trim()
 			}
 			"*AZW*" {
 				$LocalInfo['MakeAlias'] = "AZW"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace "root\WMI" ).BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "MS_SystemInformation" -Namespace "root\WMI" ).BaseBoardProduct.Trim()
 			}
 			"*Fujitsu*" {
 				$LocalInfo['MakeAlias'] = "Fujitsu"
-				$LocalInfo['ModelAlias'] = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-WmiObject -Class "Win32_BaseBoard" | Select-Object -ExpandProperty SKU).Trim()
+				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName "Win32_BaseBoard" | Select-Object -ExpandProperty SKU).Trim()
 			}
 			Default {
 				$LocalInfo['MakeAlias'] = "NA"

--- a/Scripts/PSDStart.ps1
+++ b/Scripts/PSDStart.ps1
@@ -185,7 +185,7 @@ if($BootfromWinPE -eq $true){
     # We need more than 1.5 GB (Testing for at least 1499MB of RAM)
     Write-PSDBootInfo -SleepSec 2 -Message "Checking that we have at least 1.5 GB of RAM"
     Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Checking that we have at least 1.5 GB of RAM"
-    if ((Get-WmiObject -Class Win32_computersystem).TotalPhysicalMemory -le 1499MB){
+    if ((Get-CimInstance -ClassName Win32_computersystem).TotalPhysicalMemory -le 1499MB){
         Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Not enough memory to run PSD, aborting..."
         Show-PSDInfo -Message "Not enough memory to run PSD, aborting..." -Severity Error -OSDComputername $OSDComputername -Deployroot $global:psddsDeployRoot
         Start-Process PowerShell -Wait
@@ -453,7 +453,7 @@ else{
             $ipListv4 = @()
             $macList = @()
             $gwList = @()
-            Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | % {
+            Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | % {
                 $_.IPAddress | % {$ipList += $_ }
                 $_.MacAddress | % {$macList += $_ }
                 if ($_.DefaultIPGateway) {
@@ -466,7 +466,7 @@ else{
                 Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Found IP address $IPv4"
             }
 
-            if (((Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1").Index).count -ge 1){
+            if (((Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1").Index).count -ge 1){
                 $NICIPOK = $True
                 Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): We have at least one network adapter with an IP address, continuing..."
             }

--- a/Scripts/PSDStartLoader.ps1
+++ b/Scripts/PSDStartLoader.ps1
@@ -173,7 +173,7 @@ if ($Global:PSDDebug -ne $True) {
 
 if ($BootfromWinPE -eq $true) {
 	# Windows ADK v1809 could be missing certain files, we need to check for that.
-	if ($(Get-WmiObject Win32_OperatingSystem).BuildNumber -eq "17763") {
+	if ($(Get-CimInstance -ClassName Win32_OperatingSystem).BuildNumber -eq "17763") {
 		Write-PSDLog -Message ("{0}: Check for BCP47Langs.dll and BCP47mrm.dll, needed for WPF" -f $MyInvocation.MyCommand.Name)
 		if (-not(Test-Path -Path X:\Windows\System32\BCP47Langs.dll) -or -not(Test-Path -Path X:\Windows\System32\BCP47mrm.dll)) {
 			Start-Process PowerShell -ArgumentList {
@@ -185,7 +185,7 @@ if ($BootfromWinPE -eq $true) {
 	Update-PSDStartLoaderProgressBar -Runspace $PSDStartLoader -Status "Checking that there is at least 1.5 GB of RAM..." -PercentComplete (($i++ / $Maxsteps) * 100)
 
 	Write-PSDLog -Message ("{0}: Check for minimum amount of memory in WinPE to run PSD" -f $MyInvocation.MyCommand.Name)
-	if ((Get-WmiObject -Class Win32_computersystem).TotalPhysicalMemory -le 1499MB) {
+	if ((Get-CimInstance -ClassName Win32_computersystem).TotalPhysicalMemory -le 1499MB) {
 		Show-PSDInfo -Message "Not enough memory to run PSD, aborting..." -Severity Error -OSDComputername $OSDComputername -Deployroot $global:psddsDeployRoot
 		Start-Process PowerShell -Wait
 		exit 1
@@ -435,7 +435,7 @@ else {
 			$ipListv4 = @()
 			$macList = @()
 			$gwList = @()
-			Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | % {
+			Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | % {
 				$_.IPAddress | % { $ipList += $_ }
 				$_.MacAddress | % { $macList += $_ }
 				if ($_.DefaultIPGateway) {
@@ -448,7 +448,7 @@ else {
 				Write-PSDLog -Message ("{0}: Found IP address {1}" -f $MyInvocation.MyCommand.Name, $IPv4)
 			}
 
-			if (((Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1").Index).count -ge 1) {
+			if (((Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1").Index).count -ge 1) {
 				$NICIPOK = $True
 				Write-PSDLog -Message ("{0}: We have at least one network adapter with a IP address, we should be able to continue" -f $MyInvocation.MyCommand.Name)
 			}

--- a/Scripts/PSDUtility.psm1
+++ b/Scripts/PSDUtility.psm1
@@ -677,7 +677,7 @@ Function Show-PSDInfoForm {
             $Deployroot
         )
 
-        # Make PowerShell window disappear while using GUI
+        #ï¿½Makeï¿½PowerShellï¿½window disappearï¿½while using GUI
         $windowcode = '[DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);'
         $asyncwindow = Add-Type -MemberDefinition $windowcode -name Win32ShowWindowAsync -namespace Win32Functions -PassThru
         $null = $asyncwindow::ShowWindowAsync((Get-Process -PID $pid).MainWindowHandle, 0)
@@ -701,24 +701,24 @@ Function Show-PSDInfoForm {
             }
         }
 
-        Get-WmiObject Win32_ComputerSystem | % {
+        Get-CimInstance -ClassName Win32_ComputerSystem | % {
             $Manufacturer = $_.Manufacturer
             $Model = $_.Model
             $Memory = [int] ($_.TotalPhysicalMemory / 1024 / 1024)
         }
 
-        Get-WmiObject Win32_ComputerSystemProduct | % {
+        Get-CimInstance -ClassName Win32_ComputerSystemProduct | % {
             $UUID = $_.UUID
         }
 
-        Get-WmiObject Win32_BaseBoard | % {
+        Get-CimInstance -ClassName Win32_BaseBoard | % {
             $Product = $_.Product
             $SerialNumber = $_.SerialNumber
         }
 
         try { Get-SecureBootUEFI -Name SetupMode -ErrorAction Stop; $BIOSUEFI = "UEFI" } catch { $BIOSUEFI = "BIOS" }
 
-        Get-WmiObject Win32_SystemEnclosure | % {
+        Get-CimInstance -ClassName Win32_SystemEnclosure | % {
             $AssetTag = $_.SMBIOSAssetTag.Trim()
             if ($_.ChassisTypes[0] -in "8", "9", "10", "11", "12", "14", "18", "21") { $ChassisType = "Laptop" }
             if ($_.ChassisTypes[0] -in "3", "4", "5", "6", "7", "15", "16") { $ChassisType = "Desktop" }
@@ -730,7 +730,7 @@ Function Show-PSDInfoForm {
         $ipList = @()
         $macList = @()
         $gwList = @()
-        Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | % {
+        Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 1" | % {
             $_.IPAddress | % { $ipList += $_ }
             $_.MacAddress | % { $macList += $_ }
             if ($_.DefaultIPGateway) {

--- a/Scripts/PreConfigDemo1.ps1
+++ b/Scripts/PreConfigDemo1.ps1
@@ -1,3 +1,3 @@
 ﻿Function Get-DemoTyp73{
-    (Get-WmiObject win32_computersystem).Model
+    (Get-CimInstance -ClassName win32_computersystem).Model
 }


### PR DESCRIPTION
Convert all calls to Get-WmiObject to instead use Get-CimInstance.  The Get-WmiObject calls are considered obsolete, and they don't work in Windows PE + PowerShell 7.