### PR TITLE
feat: Add usability features and enhance documentation

### DIFF
--- a/Documentation/PowerShell Deployment - IIS Configuration Guide.md
+++ b/Documentation/PowerShell Deployment - IIS Configuration Guide.md
@@ -137,6 +137,36 @@ In this section you find a list of all components being added by the setup scrip
     * Allow Verb Filtering
   * Modify Default MIME type
 
+### Verify WebDAV Functionality
+
+After running the `Set-PSDWebInstance.ps1` script or manually configuring IIS and WebDAV, it's important to verify that WebDAV is functioning correctly and that your deployment share content is accessible.
+
+Here are a couple of ways to test:
+
+1.  **Using a Web Browser (for read access):**
+    *   Open a web browser from a client machine (or the server itself).
+    *   Try to access a known file within your deployment share's virtual directory, for example, `CustomSettings.ini` located in the `Control` folder. The URL would look something like:
+        `http://yourpsdserver.yourdomain.com/YourVirtualDirectory/Control/CustomSettings.ini`
+        (Replace `yourpsdserver.yourdomain.com` with your server's FQDN and `YourVirtualDirectory` with the name of the IIS virtual directory you created for your deployment share).
+    *   If you are using Windows Authentication, you might be prompted for credentials. Use the account that has read access to your deployment share.
+    *   **Expected Result:** You should be able to view the content of the file or be prompted to download it.
+    *   **Troubleshooting:** If you receive HTTP errors like 401 (Unauthorized), 403 (Forbidden), 404 (Not Found), or 405 (Method Not Allowed), it indicates a problem with your IIS or WebDAV configuration. Review the following:
+        *   IIS Authentication settings for the virtual directory (Anonymous, Windows Auth).
+        *   WebDAV Authoring Rules (ensure rules exist for the correct users/groups with read access).
+        *   File system NTFS permissions on your deployment share folders.
+        *   Ensure the "WebDAV Publishing" feature is enabled in IIS and configured for the site.
+        *   Check IIS logs for more detailed error information.
+
+2.  **Mapping a Network Drive (more comprehensive test):**
+    *   On a Windows client machine, you can try to map a network drive to the WebDAV share.
+    *   Open File Explorer, right-click on "This PC" or "Computer," and select "Map network drive...".
+    *   For the folder, enter the WebDAV URL to your deployment share's virtual directory (e.g., `http://yourpsdserver.yourdomain.com/YourVirtualDirectory`).
+    *   If prompted, enter credentials for an account with read access.
+    *   **Expected Result:** The drive should map successfully, and you should be able to browse the folders (like `Control`, `Scripts`, etc.) within your deployment share.
+    *   **Troubleshooting:** If mapping fails, it often points to issues with WebDAV authoring rules, authentication, or the WebClient service on the client machine (ensure it's running).
+
+Verifying WebDAV access is a crucial step to ensure that PSD clients can download necessary files (like `CustomSettings.ini`, scripts, and images) when using HTTP or HTTPS deployment roots.
+
 ## Next steps
 
 To enable BranchCache (P2P) support [optional]. Go here next [PowerShell Deployment - BranchCache Installation Guide](./PowerShell%20Deployment%20-%20BranchCache%20Installation%20Guide.md)

--- a/Documentation/PowerShell Deployment - Operations Guide.md
+++ b/Documentation/PowerShell Deployment - Operations Guide.md
@@ -71,6 +71,110 @@ Edit and customize `bootstrap.ini` for your any necessary and desired configurat
 
 > PRO TIP: Recommend using the latest `bootstrap.ini` provided in repo. If using the new PSDDeployRoots property, remove *all* reference to DeployRoot from BootStrap.ini.
 
+## Configuration Backup and Restore
+
+For managing the critical configuration files of your PSD/MDT deployment share, such as `Bootstrap.ini` and `CustomSettings.ini`, a PowerShell module named `PSDConfigManager.psm1` is provided in the `Tools` directory of your deployment share. This module offers functions to easily export (backup) and import (restore) these configurations.
+
+This is particularly useful for:
+- Creating backups before making significant changes to `Bootstrap.ini` or `CustomSettings.ini`.
+- Migrating configurations between different deployment shares.
+- Restoring a last known good configuration in case of issues.
+
+To use the module, you'll first need to import it into your PowerShell session:
+```powershell
+Import-Module -Name "D:\DeploymentShareRoot\Tools\PSDConfigManager.psm1" # Adjust path as necessary
+```
+
+### Exporting Configuration (`Export-PSDConfiguration`)
+
+The `Export-PSDConfiguration` function backs up your `Bootstrap.ini` and `CustomSettings.ini` files from the `Control` directory of your deployment share to a specified backup location.
+
+**Parameters:**
+
+*   `-Path <String>`: (Mandatory) Specifies the directory where the configuration files will be backed up. The files will be stored in a subdirectory named `PSDConfigBackup` within this path.
+*   `-DeploymentShare <String>`: (Optional) Specifies the root of the MDT/PSD deployment share. If not provided, the function assumes the parent directory of the `Tools` folder (where the module resides) is the deployment share root.
+
+**Example:**
+
+To back up the configuration files from `D:\DeploymentShareRoot` to `D:\Backups\PSDConfigs`:
+
+```powershell
+Export-PSDConfiguration -Path "D:\Backups\PSDConfigs" -DeploymentShare "D:\DeploymentShareRoot"
+```
+
+This will create `D:\Backups\PSDConfigs\PSDConfigBackup` and copy `Bootstrap.ini` and `CustomSettings.ini` into it.
+
+### Importing Configuration (`Import-PSDConfiguration`)
+
+The `Import-PSDConfiguration` function restores `Bootstrap.ini` and `CustomSettings.ini` from a backup location (created by `Export-PSDConfiguration`) to the `Control` directory of your deployment share.
+
+**Important:** This function will overwrite the existing `Bootstrap.ini` and `CustomSettings.ini` files in the target `Control` directory.
+
+**Parameters:**
+
+*   `-Path <String>`: (Mandatory) Specifies the directory containing the `PSDConfigBackup` subdirectory from which the configuration files will be restored.
+*   `-DeploymentShare <String>`: (Optional) Specifies the root of the MDT/PSD deployment share where the files will be restored. If not provided, the function assumes the parent directory of the `Tools` folder is the deployment share root.
+
+**Example:**
+
+To restore configuration files to `D:\DeploymentShareRoot` from a backup located at `D:\Backups\PSDConfigs`:
+
+```powershell
+Import-PSDConfiguration -Path "D:\Backups\PSDConfigs" -DeploymentShare "D:\DeploymentShareRoot"
+```
+
+This will copy `Bootstrap.ini` and `CustomSettings.ini` from `D:\Backups\PSDConfigs\PSDConfigBackup` to `D:\DeploymentShareRoot\Control`.
+
+### Verbose Logging
+
+Both functions use `Write-Verbose` to output detailed information about their operations. To see this detailed logging, use the `-Verbose` common parameter when running the functions:
+
+```powershell
+Export-PSDConfiguration -Path "D:\Backups\PSDConfigs" -Verbose
+Import-PSDConfiguration -Path "D:\Backups\PSDConfigs" -Verbose
+```
+
+## Using the PSD Environment Configuration Tool (`PSDEnvironmentConfigurator.ps1`)
+
+To simplify common setup and maintenance tasks for your PowerShell Deployment environment, a menu-driven PowerShell script named `PSDEnvironmentConfigurator.ps1` is provided.
+
+**Location:** This script is located in the `Tools` directory of your PSD deployment share (e.g., `X:\DeploymentShare\Tools\PSDEnvironmentConfigurator.ps1`).
+
+**How to Launch:**
+To run the tool, open a PowerShell console, navigate to your deployment share's `Tools` directory, and execute the script:
+```powershell
+cd X:\DeploymentShare\Tools
+.\PSDEnvironmentConfigurator.ps1
+```
+Ensure you run this script with appropriate permissions for the tasks you intend to perform (some options may require Administrator rights).
+
+**Menu Options Overview:**
+
+The configurator provides the following options:
+
+1.  **Validate PSD Prerequisites:**
+    *   *Purpose:* Intended to check your environment for necessary roles, features, and settings required for PSD to function correctly.
+    *   *Current Status:* This is currently a placeholder. The underlying checks are yet to be implemented.
+
+2.  **Guided IIS Setup for PSD:**
+    *   *Purpose:* Designed to walk you through the configuration of Internet Information Services (IIS) if you plan to use HTTP or HTTPS for your deployments.
+    *   *Current Status:* This is currently a placeholder.
+
+3.  **Guided BranchCache Setup for PSD:**
+    *   *Purpose:* Intended to assist in setting up BranchCache for peer-to-peer content distribution, which can significantly reduce WAN traffic in distributed environments.
+    *   *Current Status:* This is currently a placeholder.
+
+4.  **Backup Deployment Share Configuration:**
+    *   *Purpose:* Provides an interactive way to back up your critical deployment share configuration files (`Bootstrap.ini` and `CustomSettings.ini`).
+    *   *Functionality:* This option utilizes the `Export-PSDConfiguration` function from the `PSDConfigManager.psm1` module (also located in the `Tools` directory). You will be prompted for a backup path.
+
+5.  **Restore Deployment Share Configuration:**
+    *   *Purpose:* Allows you to restore `Bootstrap.ini` and `CustomSettings.ini` from a previous backup.
+    *   *Functionality:* This option uses the `Import-PSDConfiguration` function from the `PSDConfigManager.psm1` module. You will be prompted for the path containing the `PSDConfigBackup` folder.
+
+**Note on Development Status:**
+Please be aware that the `PSDEnvironmentConfigurator.ps1` tool is currently under development. While the configuration backup and restore functionalities are operational (leveraging `PSDConfigManager.psm1`), several other menu options are placeholders for future enhancements.
+
 ### Update Background wallpaper
 
 By default, a new PSD themed background wallpaper (PSDBackground.bmp) is provided. It can be found at Samples folder of the MDT installation. Adjust the MDT WinPE Customizations tab to reflect this new bmp (or use your own).

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,32 @@
+# PowerShell Deployment - Documentation
+
+Welcome to the documentation for the PowerShell Deployment (PSD) toolkit. This folder contains various guides to help you install, configure, and operate PSD.
+
+## Getting Started
+
+If you are new to PSD, we recommend reading the documents in the following order:
+
+1.  **[PowerShell Deployment - Introduction.md](./PowerShell%20Deployment%20-%20Introduction.md)**: Provides a background on PSD and how it changes the MDT workflow.
+2.  **[Powershell Deployment - Beginners Guide.md](./Powershell%20Deployment%20-%20Beginners%20Guide.md)**: Covers pre-installation information, especially helpful for those new to MDT or automated deployment concepts.
+3.  **[PowerShell Deployment - Installation Guide.md](./PowerShell%20Deployment%20-%20Installation%20Guide.md)**: Detailed steps for installing PSD, including prerequisites.
+4.  **[PowerShell Deployment - IIS Configuration Guide.md](./PowerShell%20Deployment%20-%20IIS%20Configuration%20Guide.md)**: Essential guide for setting up IIS to enable HTTP/HTTPS deployments.
+5.  **[PowerShell Deployment - Operations Guide.md](./PowerShell%20Deployment%20-%20Operations%20Guide.md)**: Information on day-to-day operations, managing your deployment share, and using PSD features.
+
+## Advanced Configuration & Features
+
+For more specific scenarios or advanced setups, refer to these guides:
+
+*   **[PowerShell Deployment - BranchCache Installation Guide.md](./PowerShell%20Deployment%20-%20BranchCache%20Installation%20Guide.md)**: How to configure BranchCache for peer-to-peer content distribution.
+*   **[PowerShell Deployment - Latest Release Setup Guide.md](./PowerShell%20Deployment%20-%20Latest%20Release%20Setup%20Guide.md)**: Information specific to recent PSD releases and upgrade paths.
+*   **[PowerShell Deployment - PSD Wizard Guide.md](./PowerShell%20Deployment%20-%20PSD%20Wizard%20Guide.md)**: Details on using the PSD Wizard.
+*   **[PowerShell Deployment - RestPS Guide with PSD.md](./PowerShell%20Deployment%20-%20RestPS%20Guide%20with%20PSD.md)**: Guide for integrating RestPS with PSD.
+*   **[PowerShell Deployment - Security Guide.md](./PowerShell%20Deployment%20-%20Security%20Guide.md)**: Security considerations for your PSD environment.
+*   **[Powershell Deployment - ZeroTouch Guide.md](./Powershell%20Deployment%20-%20ZeroTouch%20Guide.md)**: Setting up Zero Touch deployments with PSD.
+
+## Reference & Support
+
+*   **[PowerShell Deployment - FAQ.md](./PowerShell%20Deployment%20-%20FAQ.md)**: Answers to frequently asked questions.
+*   **[PowerShell Deployment - PSD vs MDT.md](./PowerShell%20Deployment%20-%20PSD%20vs%20MDT.md)**: A comparison between PSD and standard MDT features.
+*   **[PowerShell Deployment - Toolkit Reference.md](./PowerShell%20Deployment%20-%20Toolkit%20Reference.md)**: Reference material for the various scripts and tools within PSD.
+
+We strive to keep this documentation up-to-date. If you find any discrepancies or areas for improvement, please consider contributing to the project.

--- a/Tools/PSDConfigManager.psm1
+++ b/Tools/PSDConfigManager.psm1
@@ -1,0 +1,252 @@
+<#
+.SYNOPSIS
+    Manages the backup and restoration of PowerShell Deployment (PSD) and Microsoft Deployment Toolkit (MDT) configuration files.
+
+.DESCRIPTION
+    This module provides functions to export (backup) and import (restore) critical configuration files 
+    such as Bootstrap.ini and CustomSettings.ini from/to an MDT/PSD deployment share.
+#>
+
+function Export-PSDConfiguration {
+<#
+.SYNOPSIS
+    Exports PSD/MDT configuration files (Bootstrap.ini, CustomSettings.ini) to a backup location.
+
+.DESCRIPTION
+    This function copies Bootstrap.ini and CustomSettings.ini from the Control directory of a 
+    deployment share to a specified backup path. It creates a subdirectory named 'PSDConfigBackup'
+    within the backup path to store these files.
+
+.PARAMETER Path
+    Specifies the directory where the configuration files will be backed up.
+    This parameter is mandatory. The backup will be stored in a 'PSDConfigBackup' subdirectory.
+
+.PARAMETER DeploymentShare
+    Specifies the root of the MDT/PSD deployment share. 
+    If not provided, the script assumes the parent directory of the 'Tools' folder (where this module resides) 
+    is the deployment share root.
+
+.EXAMPLE
+    Export-PSDConfiguration -Path "C:\Backups\MDT"
+    This command backs up Bootstrap.ini and CustomSettings.ini from the deployment share (assuming default location)
+    to "C:\Backups\MDT\PSDConfigBackup".
+
+.EXAMPLE
+    Export-PSDConfiguration -Path "C:\Backups\MDT" -DeploymentShare "D:\DeploymentShare"
+    This command backs up Bootstrap.ini and CustomSettings.ini from "D:\DeploymentShare\Control"
+    to "C:\Backups\MDT\PSDConfigBackup".
+#>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [string]$DeploymentShare
+    )
+
+    try {
+        Write-Verbose "Starting configuration export."
+
+        # Determine DeploymentShare root
+        if (-not [string]::IsNullOrWhiteSpace($DeploymentShare)) {
+            Write-Verbose "DeploymentShare parameter provided: $DeploymentShare"
+        }
+        else {
+            Write-Verbose "DeploymentShare parameter not provided. Determining default from script location."
+            # Assumes the module is in a 'Tools' subdirectory of the deployment share
+            $DeploymentShare = Split-Path $PSScriptRoot -Parent
+            Write-Verbose "Default DeploymentShare determined as: $DeploymentShare"
+        }
+
+        # Validate DeploymentShare
+        if (-not (Test-Path -Path $DeploymentShare -PathType Container)) {
+            throw "Deployment share '$DeploymentShare' not found or is not a directory."
+        }
+
+        # Define Control directory path
+        $ControlDir = Join-Path -Path $DeploymentShare -ChildPath "Control"
+        Write-Verbose "Control directory path: $ControlDir"
+
+        if (-not (Test-Path -Path $ControlDir -PathType Container)) {
+            throw "Control directory '$ControlDir' not found. Please ensure the DeploymentShare structure is correct."
+        }
+
+        # Define source files
+        $BootstrapIniSource = Join-Path -Path $ControlDir -ChildPath "Bootstrap.ini"
+        $CustomSettingsIniSource = Join-Path -Path $ControlDir -ChildPath "CustomSettings.ini"
+
+        # Check if source files exist
+        if (-not (Test-Path -Path $BootstrapIniSource -PathType Leaf)) {
+            throw "Source file '$BootstrapIniSource' not found."
+        }
+        if (-not (Test-Path -Path $CustomSettingsIniSource -PathType Leaf)) {
+            throw "Source file '$CustomSettingsIniSource' not found."
+        }
+
+        # Define backup destination
+        $BackupSubDir = "PSDConfigBackup"
+        $BackupDestination = Join-Path -Path $Path -ChildPath $BackupSubDir
+        
+        Write-Verbose "Backup destination directory: $BackupDestination"
+
+        # Create backup directory if it doesn't exist
+        if (-not (Test-Path -Path $BackupDestination -PathType Container)) {
+            Write-Verbose "Creating backup directory: $BackupDestination"
+            try {
+                New-Item -Path $BackupDestination -ItemType Directory -Force -ErrorAction Stop | Out-Null
+            }
+            catch {
+                throw "Failed to create backup directory '$BackupDestination'. Error: $($_.Exception.Message)"
+            }
+        }
+
+        # Copy Bootstrap.ini
+        $BootstrapIniDest = Join-Path -Path $BackupDestination -ChildPath "Bootstrap.ini"
+        Write-Verbose "Backing up '$BootstrapIniSource' to '$BootstrapIniDest'..."
+        try {
+            Copy-Item -Path $BootstrapIniSource -Destination $BootstrapIniDest -Force -ErrorAction Stop
+            Write-Verbose "Successfully backed up Bootstrap.ini."
+        }
+        catch {
+            throw "Failed to copy '$BootstrapIniSource' to '$BootstrapIniDest'. Error: $($_.Exception.Message)"
+        }
+
+        # Copy CustomSettings.ini
+        $CustomSettingsIniDest = Join-Path -Path $BackupDestination -ChildPath "CustomSettings.ini"
+        Write-Verbose "Backing up '$CustomSettingsIniSource' to '$CustomSettingsIniDest'..."
+        try {
+            Copy-Item -Path $CustomSettingsIniSource -Destination $CustomSettingsIniDest -Force -ErrorAction Stop
+            Write-Verbose "Successfully backed up CustomSettings.ini."
+        }
+        catch {
+            throw "Failed to copy '$CustomSettingsIniSource' to '$CustomSettingsIniDest'. Error: $($_.Exception.Message)"
+        }
+
+        Write-Verbose "Configuration export completed successfully."
+    }
+    catch {
+        Write-Error "Error during Export-PSDConfiguration: $($_.Exception.Message)"
+    }
+}
+
+function Import-PSDConfiguration {
+<#
+.SYNOPSIS
+    Imports PSD/MDT configuration files (Bootstrap.ini, CustomSettings.ini) from a backup location.
+
+.DESCRIPTION
+    This function copies Bootstrap.ini and CustomSettings.ini from a specified backup path 
+    (specifically from a 'PSDConfigBackup' subdirectory) to the Control directory of a deployment share.
+    It will overwrite existing files in the Control directory.
+
+.PARAMETER Path
+    Specifies the directory from where the configuration files will be restored.
+    This path should contain the 'PSDConfigBackup' subdirectory created by Export-PSDConfiguration.
+    This parameter is mandatory.
+
+.PARAMETER DeploymentShare
+    Specifies the root of the MDT/PSD deployment share where files will be restored. 
+    If not provided, the script assumes the parent directory of the 'Tools' folder (where this module resides) 
+    is the deployment share root.
+
+.EXAMPLE
+    Import-PSDConfiguration -Path "C:\Backups\MDT"
+    This command restores Bootstrap.ini and CustomSettings.ini from "C:\Backups\MDT\PSDConfigBackup"
+    to the Control directory of the deployment share (assuming default location).
+
+.EXAMPLE
+    Import-PSDConfiguration -Path "C:\Backups\MDT" -DeploymentShare "D:\DeploymentShare"
+    This command restores Bootstrap.ini and CustomSettings.ini from "C:\Backups\MDT\PSDConfigBackup"
+    to "D:\DeploymentShare\Control".
+#>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [string]$DeploymentShare
+    )
+
+    try {
+        Write-Verbose "Starting configuration import."
+
+        # Define backup source directory
+        $BackupSubDir = "PSDConfigBackup"
+        $BackupSourcePath = Join-Path -Path $Path -ChildPath $BackupSubDir
+        Write-Verbose "Backup source directory: $BackupSourcePath"
+
+        if (-not (Test-Path -Path $BackupSourcePath -PathType Container)) {
+            throw "Backup source directory '$BackupSourcePath' not found. Please ensure the path is correct and contains 'PSDConfigBackup' subdirectory."
+        }
+
+        # Define source files from backup
+        $BootstrapIniSource = Join-Path -Path $BackupSourcePath -ChildPath "Bootstrap.ini"
+        $CustomSettingsIniSource = Join-Path -Path $BackupSourcePath -ChildPath "CustomSettings.ini"
+
+        # Check if source files exist in backup
+        if (-not (Test-Path -Path $BootstrapIniSource -PathType Leaf)) {
+            throw "Source file '$BootstrapIniSource' not found in backup location."
+        }
+        if (-not (Test-Path -Path $CustomSettingsIniSource -PathType Leaf)) {
+            throw "Source file '$CustomSettingsIniSource' not found in backup location."
+        }
+
+        # Determine DeploymentShare root
+        if (-not [string]::IsNullOrWhiteSpace($DeploymentShare)) {
+            Write-Verbose "DeploymentShare parameter provided: $DeploymentShare"
+        }
+        else {
+            Write-Verbose "DeploymentShare parameter not provided. Determining default from script location."
+            $DeploymentShare = Split-Path $PSScriptRoot -Parent
+            Write-Verbose "Default DeploymentShare determined as: $DeploymentShare"
+        }
+
+        # Validate DeploymentShare
+        if (-not (Test-Path -Path $DeploymentShare -PathType Container)) {
+            throw "Deployment share '$DeploymentShare' not found or is not a directory."
+        }
+
+        # Define Control directory path (destination for restore)
+        $ControlDir = Join-Path -Path $DeploymentShare -ChildPath "Control"
+        Write-Verbose "Control directory path (destination): $ControlDir"
+
+        if (-not (Test-Path -Path $ControlDir -PathType Container)) {
+            # Attempt to create the Control directory if it doesn't exist? Or error out?
+            # For a restore operation, the Control directory should ideally exist.
+            throw "Control directory '$ControlDir' not found. Cannot restore files to a non-existent Control directory."
+        }
+        
+        # Restore Bootstrap.ini
+        $BootstrapIniDest = Join-Path -Path $ControlDir -ChildPath "Bootstrap.ini"
+        Write-Verbose "Restoring '$BootstrapIniSource' to '$BootstrapIniDest'..."
+        try {
+            Copy-Item -Path $BootstrapIniSource -Destination $BootstrapIniDest -Force -ErrorAction Stop
+            Write-Verbose "Successfully restored Bootstrap.ini."
+        }
+        catch {
+            throw "Failed to copy '$BootstrapIniSource' to '$BootstrapIniDest'. Error: $($_.Exception.Message)"
+        }
+
+        # Restore CustomSettings.ini
+        $CustomSettingsIniDest = Join-Path -Path $ControlDir -ChildPath "CustomSettings.ini"
+        Write-Verbose "Restoring '$CustomSettingsIniSource' to '$CustomSettingsIniDest'..."
+        try {
+            Copy-Item -Path $CustomSettingsIniSource -Destination $CustomSettingsIniDest -Force -ErrorAction Stop
+            Write-Verbose "Successfully restored CustomSettings.ini."
+        }
+        catch {
+            throw "Failed to copy '$CustomSettingsIniSource' to '$CustomSettingsIniDest'. Error: $($_.Exception.Message)"
+        }
+
+        Write-Verbose "Configuration import completed successfully."
+    }
+    catch {
+        Write-Error "Error during Import-PSDConfiguration: $($_.Exception.Message)"
+    }
+}
+
+# Export module members
+Export-ModuleMember -Function Export-PSDConfiguration
+Export-ModuleMember -Function Import-PSDConfiguration

--- a/Tools/PSDEnvironmentConfigurator.ps1
+++ b/Tools/PSDEnvironmentConfigurator.ps1
@@ -1,0 +1,163 @@
+<#
+.SYNOPSIS
+    Provides a menu-driven interface to configure and manage various aspects of a 
+    PowerShell Deployment (PSD) environment.
+
+.DESCRIPTION
+    This script offers a centralized console for common PSD setup and maintenance tasks, including:
+    - Validating prerequisites for PSD.
+    - Guided setup for IIS (for HTTP/HTTPS deployments).
+    - Guided setup for BranchCache (for peer-to-peer content distribution).
+    - Backing up critical deployment share configuration files (Bootstrap.ini, CustomSettings.ini).
+    - Restoring deployment share configuration files from a backup.
+
+    It aims to simplify the configuration process for PSD administrators.
+
+.NOTES
+    Author: AI Assistant for Software Engineering
+    Date: 2023-10-27
+    Version: 1.0.0
+
+    Requires PowerShell 5.1 or later.
+    Some options may require administrative privileges to run correctly.
+    The PSDConfigManager.psm1 module is expected to be in the same directory as this script for backup/restore functionality.
+#>
+
+#region Placeholder Functions
+
+function Validate-PSDPrequisites {
+    Write-Host "`nPlaceholder for Prerequisite Validation..." -ForegroundColor Yellow
+    Write-Host "This function will check for necessary roles, features, and settings for PSD."
+    Read-Host "Press Enter to return to the main menu"
+}
+
+function Configure-IISForPSD {
+    Write-Host "`nPlaceholder for Guided IIS Setup..." -ForegroundColor Yellow
+    Write-Host "This function will guide through configuring IIS for PSD HTTP/HTTPS deployments."
+    Read-Host "Press Enter to return to the main menu"
+}
+
+function Configure-BranchCacheForPSD {
+    Write-Host "`nPlaceholder for Guided BranchCache Setup..." -ForegroundColor Yellow
+    Write-Host "This function will guide through configuring BranchCache for PSD."
+    Read-Host "Press Enter to return to the main menu"
+}
+
+#endregion Placeholder Functions
+
+#region Configuration Backup and Restore Functions
+
+function Invoke-BackupConfiguration {
+    Write-Host "`n--- Backup Deployment Share Configuration ---" -ForegroundColor Cyan
+    $backupPath = Read-Host "Enter the full path for the configuration backup (e.g., C:\Backups\PSD)"
+    
+    if ([string]::IsNullOrWhiteSpace($backupPath)) {
+        Write-Warning "Backup path cannot be empty. Operation cancelled."
+        Read-Host "Press Enter to return to the main menu"
+        return
+    }
+
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath "PSDConfigManager.psm1"
+    
+    if (-not (Test-Path -Path $modulePath -PathType Leaf)) {
+        Write-Error "PSDConfigManager.psm1 not found at $modulePath. Cannot proceed with backup."
+        Read-Host "Press Enter to return to the main menu"
+        return
+    }
+
+    try {
+        Import-Module $modulePath -ErrorAction Stop -Force # Force to ensure latest version is loaded
+        Write-Host "Attempting to export configuration to $backupPath..." -ForegroundColor Gray
+        Export-PSDConfiguration -Path $backupPath -Verbose
+        Write-Host "Configuration backup completed successfully to '$backupPath\PSDConfigBackup'." -ForegroundColor Green
+    }
+    catch {
+        Write-Error "Failed to backup configuration. Error: $($_.Exception.Message)"
+        if ($_.Exception.InnerException) {
+            Write-Error "Inner Exception: $($_.Exception.InnerException.Message)"
+        }
+    }
+    Read-Host "Press Enter to return to the main menu"
+}
+
+function Invoke-RestoreConfiguration {
+    Write-Host "`n--- Restore Deployment Share Configuration ---" -ForegroundColor Cyan
+    $restorePath = Read-Host "Enter the full path of the directory containing 'PSDConfigBackup' (e.g., C:\Backups\PSD)"
+    
+    if ([string]::IsNullOrWhiteSpace($restorePath)) {
+        Write-Warning "Restore path cannot be empty. Operation cancelled."
+        Read-Host "Press Enter to return to the main menu"
+        return
+    }
+
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath "PSDConfigManager.psm1"
+
+    if (-not (Test-Path -Path $modulePath -PathType Leaf)) {
+        Write-Error "PSDConfigManager.psm1 not found at $modulePath. Cannot proceed with restore."
+        Read-Host "Press Enter to return to the main menu"
+        return
+    }
+    
+    if (-not (Test-Path -Path (Join-Path -Path $restorePath -ChildPath "PSDConfigBackup") -PathType Container)) {
+        Write-Error "The specified restore path does not contain a 'PSDConfigBackup' subdirectory: $restorePath"
+        Write-Error "Please ensure the path points to the parent directory of 'PSDConfigBackup'."
+        Read-Host "Press Enter to return to the main menu"
+        return
+    }
+
+    try {
+        Import-Module $modulePath -ErrorAction Stop -Force # Force to ensure latest version is loaded
+        Write-Host "Attempting to restore configuration from $restorePath..." -ForegroundColor Gray
+        Import-PSDConfiguration -Path $restorePath -Verbose
+        Write-Host "Configuration restore completed successfully from '$restorePath\PSDConfigBackup'." -ForegroundColor Green
+    }
+    catch {
+        Write-Error "Failed to restore configuration. Error: $($_.Exception.Message)"
+        if ($_.Exception.InnerException) {
+            Write-Error "Inner Exception: $($_.Exception.InnerException.Message)"
+        }
+    }
+    Read-Host "Press Enter to return to the main menu"
+}
+
+#endregion Configuration Backup and Restore Functions
+
+#region Main Menu Loop
+
+function Show-MainMenu {
+    Clear-Host
+    Write-Host "=================================================" -ForegroundColor Green
+    Write-Host "  PowerShell Deployment Environment Configurator " -ForegroundColor White
+    Write-Host "=================================================" -ForegroundColor Green
+    Write-Host
+    Write-Host "  1. Validate PSD Prerequisites" -ForegroundColor Yellow
+    Write-Host "  2. Guided IIS Setup for PSD" -ForegroundColor Yellow
+    Write-Host "  3. Guided BranchCache Setup for PSD" -ForegroundColor Yellow
+    Write-Host "  4. Backup Deployment Share Configuration" -ForegroundColor Yellow
+    Write-Host "  5. Restore Deployment Share Configuration" -ForegroundColor Yellow
+    Write-Host
+    Write-Host "  Q. Quit" -ForegroundColor Yellow
+    Write-Host
+}
+
+do {
+    Show-MainMenu
+    $choice = Read-Host "Enter your choice"
+
+    switch ($choice) {
+        '1' { Validate-PSDPrequisites }
+        '2' { Configure-IISForPSD }
+        '3' { Configure-BranchCacheForPSD }
+        '4' { Invoke-BackupConfiguration }
+        '5' { Invoke-RestoreConfiguration }
+        'Q' { Write-Host "Exiting script. Goodbye!" }
+        default {
+            Write-Warning "Invalid choice. Please select a valid option."
+            Read-Host "Press Enter to continue"
+        }
+    }
+} while ($choice -ne 'Q')
+
+#endregion Main Menu Loop
+
+Write-Host "`nScript finished."


### PR DESCRIPTION
This commit introduces several new features and documentation improvements to enhance the user-friendliness of the PowerShell Deployment (PSD) toolkit:

1.  **Configuration Backup and Restore:**
    *   Added `Tools/PSDConfigManager.psm1`, a new PowerShell module with
        `Export-PSDConfiguration` and `Import-PSDConfiguration` functions
        to back up and restore `Bootstrap.ini` and `CustomSettings.ini`
        from the deployment share's `Control` directory.
    *   Updated `Documentation/PowerShell Deployment - Operations Guide.md`
        with instructions on using these new functions.

2.  **Interactive PSD Environment Configuration Tool:**
    *   Added `Tools/PSDEnvironmentConfigurator.ps1`, a new PowerShell
        script that provides a menu-driven interface for common PSD tasks.
    *   Current features include invoking the configuration backup/restore
        functionality.
    *   Placeholders for future features: PSD prerequisite validation,
        guided IIS setup, and guided BranchCache setup.
    *   Updated `Documentation/PowerShell Deployment - Operations Guide.md`
        to include details about this tool.

3.  **Documentation Enhancements:**
    *   Populated the previously empty `Documentation/README.md` with an
        overview and links to existing documentation files, improving
        documentation discoverability.

**Note on Comment-Based Help:**
I attempted to add comprehensive comment-based help to existing large PowerShell modules (specifically `PSDUtility.psm1` and `PSDGather.psm1`) but was unsuccessful due to persistent errors. This task was skipped to allow progress on other planned features. Manual review and update of comment-based help for these modules is recommended.

The implemented features are designed to be additive and have undergone conceptual testing to ensure they integrate without disrupting existing PSD functionality.