### PR TITLE
Delete

### DIFF
--- a/Scripts/PSDCustomization.ps1
+++ b/Scripts/PSDCustomization.ps1
@@ -66,6 +66,20 @@ switch ($Config)
 
     }
     Default {
+        Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Attempting to hide DOadmin account from login screen."
+        try {
+            $RegPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList"
+            # Ensure the parent path exists
+            if (-not (Test-Path $RegPath)) {
+                New-Item -Path $RegPath -Force | Out-Null
+                Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Created registry path $RegPath."
+            }
+            New-ItemProperty -Path $RegPath -Name "DOadmin" -Value 0 -PropertyType DWord -Force -ErrorAction Stop
+            Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Successfully set registry key to hide DOadmin account."
+        }
+        catch {
+            Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Error setting registry key to hide DOadmin account. Error: $($_.Exception.Message)" -LogLevel 3
+        }
     }
 }
 

--- a/Scripts/PSDWizardNew/Themes/Classic/PSDWizard_AdminCreds_en-US.xaml
+++ b/Scripts/PSDWizardNew/Themes/Classic/PSDWizard_AdminCreds_en-US.xaml
@@ -15,9 +15,12 @@
     <Label Content="Password:" HorizontalAlignment="Right" FontSize="14" Margin="0,138,332,378"/>
     <PasswordBox x:Name="TS_AdminPassword" Margin="164,138,14,378" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center"/>
     <Label Content="Confirm Password:" FontSize="14" Margin="35,177,324,340"/>
-    <PasswordBox x:Name="_ConfirmAdminPassword"  Margin="164,177,14,340" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center"/>
+    <PasswordBox x:Name="_ConfirmAdminPassword" Margin="164,177,14,340" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center"/>
 
-    <Canvas x:Name="_admTabValidation" Margin="10,215,14,286" Visibility="Hidden">
+    <Label Content="DOuser Password:" HorizontalAlignment="Right" FontSize="14" Margin="0,216,332,301"/>
+    <PasswordBox x:Name="TS_DOUserPassword" Margin="164,216,14,301" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center"/>
+
+    <Canvas x:Name="_admTabValidation" Margin="10,254,14,247" Visibility="Hidden">
         <TextBox x:Name="_admTabValidation_Name" Background="Transparent" BorderThickness="0" TextWrapping="NoWrap" FontSize="18" IsReadOnly="True" Canvas.Left="10" Canvas.Top="10" Height="30" />
         <Rectangle x:Name="_admTabValidation_Alert" Width="30" Height="30" Fill="Red" Canvas.Left="426" Canvas.Top="10" Visibility="Hidden">
             <Rectangle.OpacityMask>
@@ -31,9 +34,9 @@
         </Rectangle>
     </Canvas>
 
-    <Label x:Name="_admOSDAddAdminText" Content="Administrator user accounts" FontSize="18" HorizontalAlignment="Left" Margin="10,326,0,0" VerticalAlignment="Top" Width="466"/>
-    <Label x:Name="_admOSDAddAdminLabel" Content="Admin Accounts(s)" HorizontalAlignment="Right" FontSize="14" Margin="0,364,330,152" Width="126"/>
-    <TextBox x:Name="TS_OSDAddAdmin" Margin="165,364,14,152" FontSize="14" FontWeight="Bold" TextWrapping="NoWrap" VerticalContentAlignment="Center" IsEnabled="False"/>
+    <Label x:Name="_admOSDAddAdminText" Content="Administrator user accounts" FontSize="18" HorizontalAlignment="Left" Margin="10,365,0,0" VerticalAlignment="Top" Width="466"/>
+    <Label x:Name="_admOSDAddAdminLabel" Content="Admin Accounts(s)" HorizontalAlignment="Right" FontSize="14" Margin="0,403,330,113" Width="126"/>
+    <TextBox x:Name="TS_OSDAddAdmin" Margin="165,403,14,113" FontSize="14" FontWeight="Bold" TextWrapping="NoWrap" VerticalContentAlignment="Center" IsEnabled="False"/>
 
     <Label Content="More Info" Grid.Column="1" FontSize="14" HorizontalAlignment="Left" Margin="10,31,0,0" VerticalAlignment="Top" Foreground="LightSlateGray"/>
     <TextBlock x:Name="_admTabMoreInfo" Grid.Column="1" HorizontalAlignment="Left" Margin="10,89,0,0" Width="136" TextWrapping="Wrap" VerticalAlignment="Top" Height="422">

--- a/Scripts/PSDWizardNew/Themes/Dark/PSDWizard_AdminCreds_en-US.xaml
+++ b/Scripts/PSDWizardNew/Themes/Dark/PSDWizard_AdminCreds_en-US.xaml
@@ -15,9 +15,12 @@
     <Label Content="Password:" HorizontalAlignment="Right" FontSize="14" Margin="0,138,332,378"/>
     <PasswordBox x:Name="TS_AdminPassword" Margin="164,138,14,378" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center" Style="{DynamicResource PasswordDarkTheme}"/>
     <Label Content="Confirm Password:" FontSize="14" Margin="35,177,324,340"/>
-    <PasswordBox x:Name="_ConfirmAdminPassword"  Margin="164,177,14,340" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center"  Style="{DynamicResource PasswordDarkTheme}"/>
+    <PasswordBox x:Name="_ConfirmAdminPassword" Margin="164,177,14,340" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center"  Style="{DynamicResource PasswordDarkTheme}"/>
 
-    <Canvas x:Name="_admTabValidation" Margin="10,215,14,286" Background="LightGreen" Visibility="Visible">
+    <Label Content="DOuser Password:" HorizontalAlignment="Right" FontSize="14" Margin="0,216,332,301"/>
+    <PasswordBox x:Name="TS_DOUserPassword" Margin="164,216,14,301" FontSize="14" FontWeight="Bold" VerticalContentAlignment="Center" Style="{DynamicResource PasswordDarkTheme}"/>
+
+    <Canvas x:Name="_admTabValidation" Margin="10,254,14,247" Background="LightGreen" Visibility="Visible">
         <TextBox x:Name="_admTabValidation_Name" Background="Transparent" BorderThickness="0" TextWrapping="NoWrap" FontSize="18" IsReadOnly="True" Canvas.Left="10" Canvas.Top="10" Width="376" Height="30" Text="test" />
         <Rectangle x:Name="_admTabValidation_Alert" Width="30" Height="30" Fill="Red" Canvas.Left="426" Canvas.Top="10" Visibility="Visible">
             <Rectangle.OpacityMask>
@@ -31,9 +34,9 @@
         </Rectangle>
     </Canvas>
 
-    <Label x:Name="_admOSDAddAdminText" Content="Administrator user accounts" FontSize="18" HorizontalAlignment="Left" Margin="10,326,0,0" VerticalAlignment="Top" Width="466"/>
-    <Label x:Name="_admOSDAddAdminLabel" Content="Admin Accounts(s)" HorizontalAlignment="Right" FontSize="14" Margin="0,364,330,152" Width="126"/>
-    <TextBox x:Name="TS_OSDAddAdmin" Margin="165,364,14,152" FontSize="14" FontWeight="Bold" TextWrapping="NoWrap" VerticalContentAlignment="Center" IsEnabled="False" Style="{DynamicResource TextBoxDarkTheme}"/>
+    <Label x:Name="_admOSDAddAdminText" Content="Administrator user accounts" FontSize="18" HorizontalAlignment="Left" Margin="10,365,0,0" VerticalAlignment="Top" Width="466"/>
+    <Label x:Name="_admOSDAddAdminLabel" Content="Admin Accounts(s)" HorizontalAlignment="Right" FontSize="14" Margin="0,403,330,113" Width="126"/>
+    <TextBox x:Name="TS_OSDAddAdmin" Margin="165,403,14,113" FontSize="14" FontWeight="Bold" TextWrapping="NoWrap" VerticalContentAlignment="Center" IsEnabled="False" Style="{DynamicResource TextBoxDarkTheme}"/>
     <Label Content="More Info" Grid.Column="1" FontSize="14" HorizontalAlignment="Left" Margin="10,31,0,0" VerticalAlignment="Top" Foreground="LightSlateGray"/>
     <TextBlock x:Name="_admTabMoreInfo" Grid.Column="1" HorizontalAlignment="Left" Margin="10,89,0,0" Width="136" TextWrapping="Wrap" VerticalAlignment="Top" Height="422">
         <Run Text="@Help"/>

--- a/Scripts/ZTIConfigure.xml
+++ b/Scripts/ZTIConfigure.xml
@@ -214,4 +214,7 @@
 	<mapping id="DestinationPartition" type="xml">
                 <xpath><![CDATA[//unattend:settings[@pass="windowsPE"]/unattend:component[@name="Microsoft-Windows-Setup"]/unattend:ImageInstall/unattend:OSImage/unattend:InstallTo/unattend:PartitionID]]></xpath>
 	</mapping>
+	<mapping id="DOUserPassword" type="xml">
+		<xpath><![CDATA[//unattend:settings[@pass='oobeSystem']/unattend:component[@name='Microsoft-Windows-Shell-Setup']/unattend:UserAccounts/unattend:LocalAccounts/unattend:LocalAccount[unattend:Name='DOuser']/unattend:Password/unattend:Value]]></xpath>
+	</mapping>
 </mappings>

--- a/Templates/Unattend_x64.xml
+++ b/Templates/Unattend_x64.xml
@@ -81,6 +81,24 @@
                     <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>%DOUserPassword%</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Users</Group>
+                        <Name>DOuser</Name>
+                    </LocalAccount>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>DigiOpto2018</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <Name>DOadmin</Name>
+                    </LocalAccount>
+                </LocalAccounts>
             </UserAccounts>
             <AutoLogon>
                 <Enabled>true</Enabled>

--- a/Templates/Unattend_x64.xml.10.0
+++ b/Templates/Unattend_x64.xml.10.0
@@ -84,6 +84,24 @@
                     <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>%DOUserPassword%</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Users</Group>
+                        <Name>DOuser</Name>
+                    </LocalAccount>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>DigiOpto2018</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <Name>DOadmin</Name>
+                    </LocalAccount>
+                </LocalAccounts>
             </UserAccounts>
             <AutoLogon>
                 <Enabled>true</Enabled>

--- a/Templates/Unattend_x86.xml
+++ b/Templates/Unattend_x86.xml
@@ -81,6 +81,24 @@
                     <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>%DOUserPassword%</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Users</Group>
+                        <Name>DOuser</Name>
+                    </LocalAccount>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>DigiOpto2018</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <Name>DOadmin</Name>
+                    </LocalAccount>
+                </LocalAccounts>
             </UserAccounts>
             <AutoLogon>
                 <Enabled>true</Enabled>

--- a/Templates/Unattend_x86.xml.10.0
+++ b/Templates/Unattend_x86.xml.10.0
@@ -84,6 +84,24 @@
                     <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>%DOUserPassword%</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Users</Group>
+                        <Name>DOuser</Name>
+                    </LocalAccount>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>DigiOpto2018</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <Name>DOadmin</Name>
+                    </LocalAccount>
+                </LocalAccounts>
             </UserAccounts>
             <AutoLogon>
                 <Enabled>true</Enabled>


### PR DESCRIPTION
This commit introduces functionality for creating two local user accounts during deployment: DOuser and DOadmin.

DOuser:
- An option to set a password for DOuser has been added to the deployment wizard (Classic and Dark themes).
- The `unattend.xml` templates have been updated to include DOuser, with its password populated from the wizard input via a new `DOUserPassword` variable mapped in `ZTIConfigure.xml`.
- DOuser is added to the "Users" group.

DOadmin:
- A local administrator account named DOadmin is now created with a hardcoded password ("DigiOpto2018") via `unattend.xml` templates.
- `PSDCustomization.ps1` has been modified to add a registry entry that hides the DOadmin account from the Windows login screen.

Affected files:
- `Templates/Unattend_x64.xml`
- `Templates/Unattend_x86.xml`
- `Templates/Unattend_x64.xml.10.0`
- `Templates/Unattend_x86.xml.10.0`
- `Scripts/ZTIConfigure.xml`
- `Scripts/PSDWizardNew/Themes/Classic/PSDWizard_AdminCreds_en-US.xaml`
- `Scripts/PSDWizardNew/Themes/Dark/PSDWizard_AdminCreds_en-US.xaml`
- `Scripts/PSDCustomization.ps1`