### PR TITLE
Start-Bitstransfer update

### DIFF
--- a/Scripts/PSDCopyLogs.ps1
+++ b/Scripts/PSDCopyLogs.ps1
@@ -60,7 +60,7 @@ if ($tsenv:SLShare -ilike "http*"){
             $SourceFolderToZIP = "$Folder"
             $SourceFile = "$env:TEMP\$FolderName.zip"
             Compress-Archive -Path $SourceFolderToZIP -DestinationPath $SourceFile -Verbose -Force
-            Start-BitsTransfer -Authentication Ntlm -Source $SourceFile -Destination $("$tsenv:SLshare/$env:COMPUTERNAME-" + "$LogName" + ".zip") -TransferType Upload -Verbose -Credential $Credentials
+            Start-BitsTransfer -Authentication Negotiate -Source $SourceFile -Destination $("$tsenv:SLshare/$env:COMPUTERNAME-" + "$LogName" + ".zip") -TransferType Upload -Verbose -Credential $Credentials
         }
     }
 }

--- a/Scripts/PSDDeploymentShare.psm1
+++ b/Scripts/PSDDeploymentShare.psm1
@@ -413,7 +413,7 @@ function Get-PSDContentWeb {
             }
             # Do the download using BITS
             Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Downloading files using BITS."
-            $bitsJob = Start-BitsTransfer -Authentication Ntlm -Credential $global:psddsCredential -Source $sourceUrl -Destination $destFile -TransferType Download -DisplayName "PSD Transfer" -Priority High
+            $bitsJob = Start-BitsTransfer -Authentication Negotiate -Credential $global:psddsCredential -Source $sourceUrl -Destination $destFile -TransferType Download -DisplayName "PSD Transfer" -Priority High
         }
     }
 }

--- a/Scripts/PSDUtility.psm1
+++ b/Scripts/PSDUtility.psm1
@@ -400,7 +400,7 @@ Function Copy-PSDLogs {
 
             $RemoteFileName = $($env:COMPUTERNAME) + "-" + $Name + ".zip"
             try {
-                Start-BitsTransfer -Authentication Ntlm -Source $LogArchive -Destination $("$tsenv:SLshare/$RemoteFileName") -TransferType Upload -Credential $Credentials -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+                Start-BitsTransfer -Authentication Negotiate -Source $LogArchive -Destination $("$tsenv:SLshare/$RemoteFileName") -TransferType Upload -Credential $Credentials -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             }
             catch {
             }


### PR DESCRIPTION
This changes from the -authentication NTLM to Negotiate. This is default and recommend by Microsoft. This also works with Server 2022