### PR TITLE
Fix for certain QEMU based VMs where the serial number.

### DIFF
--- a/Scripts/PSDGather.psm1
+++ b/Scripts/PSDGather.psm1
@@ -76,7 +76,7 @@ Function Get-PSDLocalInfo {
 		$LocalInfo['IsServerOS'] = "False"
 
 		# Look up OS details
-		Get-CimInstance -ClassName Win32_OperatingSystem | ForEach-Object { $LocalInfo['OSCurrentVersion'] = $_.Version; $LocalInfo['OSCurrentBuild'] = $_.BuildNumber }
+		Get-CimInstance -ClassName Win32_OperatingSystem -Property Version, BuildNumber, OperatingSystemSKU | ForEach-Object { $LocalInfo['OSCurrentVersion'] = $_.Version; $LocalInfo['OSCurrentBuild'] = $_.BuildNumber; $sku = $_.OperatingSystemSKU }
 		if (Test-Path HKLM:System\CurrentControlSet\Control\MiniNT) {
 			$LocalInfo['OSVersion'] = "WinPE"
 		}
@@ -115,7 +115,7 @@ Function Get-PSDLocalInfo {
 		$LocalInfo['IsSFF'] = "False"
 		$LocalInfo['IsTablet'] = "False"
 		Get-CimInstance -ClassName Win32_SystemEnclosure | ForEach-Object {
-			$LocalInfo['AssetTag'] = $_.SMBIOSAssetTag.Trim()
+			$LocalInfo['AssetTag'] = "$($_.SMBIOSAssetTag)".Trim()
 			if ($_.ChassisTypes[0] -in "8", "9", "10", "11", "12", "14", "18", "21") { $LocalInfo['IsLaptop'] = "True"; $LocalInfo['Chassis'] = "Laptop"}
 			if ($_.ChassisTypes[0] -in "3", "4", "5", "6", "7", "15", "16") { $LocalInfo['IsDesktop'] = "True"; $LocalInfo['Chassis'] = "Desktop"}
 			if ($_.ChassisTypes[0] -in "23") { $LocalInfo['IsServer'] = "True"; $LocalInfo['Chassis'] = "Server"}
@@ -124,8 +124,7 @@ Function Get-PSDLocalInfo {
 		}
 
 		Get-CimInstance -ClassName Win32_BIOS | ForEach-Object {
-    		$SerialNumber = $_.SerialNumber
-    		$LocalInfo['SerialNumber'] = if ([string]::IsNullOrWhiteSpace($SerialNumber)) { "" } else { $SerialNumber.Trim() }
+    		$LocalInfo['SerialNumber'] =  "$($_.SerialNumber)".Trim()
 		}
 
 		if ($env:PROCESSOR_ARCHITEW6432) {
@@ -153,34 +152,34 @@ Function Get-PSDLocalInfo {
 		# TODO: Capable architecture
 
 		Get-CimInstance -ClassName Win32_ComputerSystem | ForEach-Object {
-			$LocalInfo['Manufacturer'] = $_.Manufacturer.Trim()
-			$LocalInfo['Make'] = $_.Manufacturer.Trim()
-			$LocalInfo['Model'] = $_.Model.Trim()
+			$LocalInfo['Manufacturer'] = "$($_.Manufacturer)".Trim()
+			$LocalInfo['Make'] = "$($_.Manufacturer)".Trim()
+			$LocalInfo['Model'] = "$($_.Model)".Trim()
 			$LocalInfo['Memory'] = [int] ($_.TotalPhysicalMemory / 1024 / 1024)
 		}
 
 		if ($LocalInfo['Make'] -eq "") {
-			$Make = (Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty Manufacturer).Trim()
+			$Make = "$(Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty Manufacturer)".Trim()
 			$LocalInfo['Make'] = $Make
 			$LocalInfo['Manufacturer'] = $Make
 		}
 
 		if ($LocalInfo['Model'] -eq "") {
-			$LocalInfo['Model'] = (Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty Product).Trim()
+			$LocalInfo['Model'] = "$(Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty Product)".Trim()
 		}
 
 		Get-CimInstance -ClassName Win32_ComputerSystemProduct | ForEach-Object {
-			$LocalInfo['UUID'] = $_.UUID.Trim()
-			$LocalInfo['CSPVersion'] = $_.Version.Trim()
+			$LocalInfo['UUID'] = "$($_.UUID)".Trim()
+			$LocalInfo['CSPVersion'] = "$($_.Version)".Trim()
 		}
 
 		Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\WMI | ForEach-Object {
-			$LocalInfo['BaseBoardProduct'] = $_.BaseBoardProduct.Trim()
-			$LocalInfo['SystemSku'] = $_.SystemSku.Trim()
+			$LocalInfo['BaseBoardProduct'] = "$($_.BaseBoardProduct)".Trim()
+			$LocalInfo['SystemSku'] = "$($_.SystemSku)".Trim()
 		}
 
 		Get-CimInstance -ClassName Win32_BaseBoard | ForEach-Object {
-			$LocalInfo['Product'] = $_.Product.Trim()
+			$LocalInfo['Product'] = "$($_.Product)".Trim()
 		}
 
 		# UEFI
@@ -262,80 +261,89 @@ Function Get-PSDLocalInfo {
 		Switch -Wildcard ($LocalInfo['Make']) {
 			"*Microsoft*" {
 				$LocalInfo['MakeAlias'] = "Microsoft"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
 				$LocalInfo['SystemAlias'] = Get-CimInstance -ClassName MS_SystemInformation -Namespace root\wmi | Select-Object -ExpandProperty SystemSKU
 				# Logic for Hyper-V Testing
 				If ($LocalInfo['ModelAlias'] -eq "Virtual Machine") {
 					$LocalInfo['SystemAlias'] = Get-CimInstance -ClassName MS_SystemInformation -Namespace root\wmi | Select-Object -ExpandProperty SystemVersion
+					if ([string]::IsNullOrEmpty($LocalInfo['SystemAlias']))
+					{
+						$LocalInfo['SystemAlias'] = $LocalInfo['ModelAlias']
+					}
 					$LocalInfo['IsVM'] = "True"
 				}
 			}
 			"*HP*" {
 				$LocalInfo['MakeAlias'] = "HP"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi).BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$((Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi).BaseBoardProduct)".Trim()
 			}
 			"*VMWare*" {
 				$LocalInfo['MakeAlias'] = "VMWare"
                 # $LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim() # Default, sets alias to same as model
                 # $LocalInfo['ModelAlias'] = ((Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()).replace(",","_") # Remove the "," and replace with "_"
-                $LocalInfo['ModelAlias'] = ((Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()).replace(" ","_").replace(",","_") # Remove the "," and replace with "_", Remove the " " and replace with "_"
+                $LocalInfo['ModelAlias'] = ("$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()).replace(" ","_").replace(",","_") # Remove the "," and replace with "_", Remove the " " and replace with "_"
 
 				$LocalInfo['SystemAlias'] = Get-CimInstance -ClassName MS_SystemInformation -Namespace root\wmi | Select-Object -ExpandProperty SystemSKU
 				$LocalInfo['IsVM'] = "True"
 			}
 			"*QEMU*" {
 				$LocalInfo['MakeAlias'] = "QEMU"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
 				$LocalInfo['SystemAlias'] = Get-CimInstance -ClassName MS_SystemInformation -Namespace root\wmi | Select-Object -ExpandProperty SystemSKU
 				$LocalInfo['IsVM'] = "True"
 			}
 			"*Innotek*" {
 				$LocalInfo['MakeAlias'] = "Innotek"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
 				$LocalInfo['SystemAlias'] = Get-CimInstance -ClassName MS_SystemInformation -Namespace root\wmi | Select-Object -ExpandProperty SystemSKU
 				$LocalInfo['IsVM'] = "True"
 			}
 			"*Hewlett-Packard*" {
 				$LocalInfo['MakeAlias'] = "HP"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi).BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$((Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi).BaseBoardProduct)".Trim()
 			}
 			"*Dell*" {
 				$LocalInfo['MakeAlias'] = "Dell"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi ).SystemSku.Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$((Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi ).SystemSku)".Trim()
 			}
 			"*Lenovo*" {
 				$LocalInfo['MakeAlias'] = "Lenovo"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystemProduct | Select-Object -ExpandProperty Version).Trim()
-				$LocalInfo['SystemAlias'] = ((Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).SubString(0, 4)).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystemProduct | Select-Object -ExpandProperty Version)".Trim()
+				$LocalInfo['SystemAlias'] = "$((Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).SubString(0, 4))".Trim()
 			}
 			"*Intel(R) Client Systems*" {
 				$LocalInfo['MakeAlias'] = "Intel(R) Client Systems"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystemProduct | Select-Object -ExpandProperty Version).Trim()
-				$LocalInfo['SystemAlias'] = ((Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim())
-				$LocalInfo['SystemAlias'] = $LocalInfo['SystemAlias'].SubString(0, $LocalInfo['SystemAlias'].IndexOf("i")).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystemProduct | Select-Object -ExpandProperty Version)".Trim()
+				$LocalInfo['SystemAlias'] = ("$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim())
+				$LocalInfo['SystemAlias'] = "$($LocalInfo['SystemAlias'].SubString(0, $LocalInfo['SystemAlias'].IndexOf("i")))".Trim()
 			}
 			"*Panasonic*" {
 				$LocalInfo['MakeAlias'] = "Panasonic Corporation"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi ).BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$((Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi ).BaseBoardProduct)".Trim()
 			}
 			"*Viglen*" {
 				$LocalInfo['MakeAlias'] = "Viglen"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty SKU).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$(Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty SKU)".Trim()
 			}
 			"*AZW*" {
 				$LocalInfo['MakeAlias'] = "AZW"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi ).BaseBoardProduct.Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$((Get-CimInstance -ClassName MS_SystemInformation -NameSpace root\wmi ).BaseBoardProduct)".Trim()
 			}
 			"*Fujitsu*" {
 				$LocalInfo['MakeAlias'] = "Fujitsu"
-				$LocalInfo['ModelAlias'] = (Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model).Trim()
-				$LocalInfo['SystemAlias'] = (Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty SKU).Trim()
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = "$(Get-CimInstance -ClassName Win32_BaseBoard | Select-Object -ExpandProperty SKU)".Trim()
+			}
+			"*Acer*" {
+				$LocalInfo['MakeAlias'] = "Acer"
+				$LocalInfo['ModelAlias'] = "$(Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Model)".Trim()
+				$LocalInfo['SystemAlias'] = $LocalInfo['ModelAlias']
 			}
 			Default {
 				$LocalInfo['MakeAlias'] = "NA"

--- a/Scripts/PSDGather.psm1
+++ b/Scripts/PSDGather.psm1
@@ -124,7 +124,8 @@ Function Get-PSDLocalInfo {
 		}
 
 		Get-CimInstance -ClassName Win32_BIOS | ForEach-Object {
-			$LocalInfo['SerialNumber'] = $_.SerialNumber.Trim()
+    		$SerialNumber = $_.SerialNumber
+    		$LocalInfo['SerialNumber'] = if ([string]::IsNullOrWhiteSpace($SerialNumber)) { "" } else { $SerialNumber.Trim() }
 		}
 
 		if ($env:PROCESSOR_ARCHITEW6432) {


### PR DESCRIPTION
Fix for certain QEMU based VMs where the serial number can be blank/null and make the script fail, this fix will then set it to an empty string.